### PR TITLE
Add comparison exit code

### DIFF
--- a/compare_geometry.py
+++ b/compare_geometry.py
@@ -24,7 +24,7 @@ class ExitCode(IntEnum):
     ERROR = 2
 
 
-FAILURES = []
+FAILURES: List[str] = []
 
 
 @dataclass
@@ -406,7 +406,7 @@ def compare_indexed_volumes(
             if not match_res.is_equal:
                 message = f"For volume {volume_id}, matcher {matcher}: {match_res}"
                 _logger.warning(message)
-                FAILURES.append((file_info, message))
+                FAILURES.append(f"For files: {file_info}\t{message}")
     return all_results
 
 

--- a/compare_geometry.py
+++ b/compare_geometry.py
@@ -393,7 +393,9 @@ def compare_indexed_volumes(
         _logger.info(f"comparing volume: {volume_id}")
         gemc3_vol = gemc3_volumes.get(volume_id, None)
         if gemc3_vol is None:
-            _logger.warning(f'\nVolume "{volume_id}" not found in gemc3\n')
+            message = f'Volume "{volume_id}" not found in gemc3'
+            _logger.warning(f"\n{message}\n")
+            FAILURES.append(f"For files: {file_info}\t{message}")
             continue
         match_results = {}
         for func in matchers:


### PR DESCRIPTION
This PR adds the exit code to the gemc2-gemc3 comparison script. The validate workflow fails if there is a difference between gemc2 and gemc3 files. 

Questions:

- for target there are 2 differences. Can we adjust it in gemc2?
```
ERROR:compare_geometry:The following matcher failures were detected:
ERROR:compare_geometry:For files: /jlab/clas12Tags/5.0/experiments/clas12/targets/target__geometry_ND3.txt -> /__w/clas12-systems/clas12-systems/systemsTxtDB/clas12Target__geometry_nd3.txt	For volume HeliumCell, matcher matches_material: MatcherResult(is_equal=False, name='material', gemc2_attribute='G4_Galactic', gemc3_attribute='G4_He')
For files: /jlab/clas12Tags/5.0/experiments/clas12/targets/target__geometry_ND3.txt -> /__w/clas12-systems/clas12-systems/systemsTxtDB/clas12Target__geometry_nd3.txt	For volume ND3, matcher matches_color: MatcherResult(is_equal=False, name='color', gemc2_attribute='ee8811Q', gemc3_attribute='ee8811')
```
- there are also differences (beyond the unknown volumes) in ft_cal https://github.com/mariakzurek/clas12-systems/runs/6531028664?check_suite_focus=true
```
For files: /jlab/clas12Tags/5.0/experiments/clas12/ft/ft__geometry_FTOff.txt -> /__w/clas12-systems/clas12-systems/systemsTxtDB/ft_cal__geometry_default.txt	For volume ft_cal_tcup_back, matcher matches_material: MatcherResult(is_equal=False, name='material', gemc2_attribute='ft_W', gemc3_attribute='G4_W')
For files: /jlab/clas12Tags/5.0/experiments/clas12/ft/ft__geometry_FTOff.txt -> /__w/clas12-systems/clas12-systems/systemsTxtDB/ft_cal__geometry_default.txt	For volume ft_cal_tcup_front, matcher matches_material: MatcherResult(is_equal=False, name='material', gemc2_attribute='ft_W', gemc3_attribute='G4_W')
```
and

```
INFO:compare_geometry:comparing volume: ft_cal
WARNING:compare_geometry:For volume ft_cal, matcher matches_visibility: MatcherResult(is_equal=False, name='visibility', gemc2_attribute='0', gemc3_attribute='1')
```